### PR TITLE
Integrate governance modules via ServiceManager

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 #TODO
 
-7. **Governance modules**
-   - Hook up `ContentModeration` and `UpgradeManager` through a `ServiceManager` or RPC interface.
-   - Allow proposals, voting and upgrade activation according to the whitepaper rules.
-
 8. **Public query endpoints**
    - Build a read‑only HTTP or gRPC service exposing metrics and simple queries on the pinned database.
    - Document how non‑nodes can download snapshots from IPFS.

--- a/src/network/service_manager.hpp
+++ b/src/network/service_manager.hpp
@@ -1,18 +1,17 @@
 #ifndef RXREVOLTCHAIN_SERVICE_MANAGER_HPP
 #define RXREVOLTCHAIN_SERVICE_MANAGER_HPP
 
+#include "content_moderation.hpp"
+#include "document_queue.hpp"
+#include "upgrade_manager.hpp"
+#include <mutex>
 #include <string>
 #include <vector>
-#include <mutex>
-#include "document_queue.hpp"
-#include "content_moderation.hpp"
-#include "upgrade_manager.hpp"
 
 namespace rxrevoltchain {
 namespace network {
 
-struct Request
-{
+struct Request {
     // The type of the request, e.g., "SubmitDoc", "RemoveDoc", "GetStatus", etc.
     std::string requestType;
 
@@ -23,13 +22,11 @@ struct Request
     Request() = default;
 
     // Helpful convenience constructor
-    Request(const std::string &type, const std::vector<uint8_t> &data)
-        : requestType(type), payload(data)
-    {}
+    Request(const std::string& type, const std::vector<uint8_t>& data)
+        : requestType(type), payload(data) {}
 };
 
-struct Response
-{
+struct Response {
     // Indicates if the request was successful
     bool success;
 
@@ -40,14 +37,11 @@ struct Response
     std::vector<uint8_t> payload;
 
     // Default constructor
-    Response()
-        : success(false)
-    {}
+    Response() : success(false) {}
 
     // Convenience constructor
-    Response(bool ok, const std::string &msg, const std::vector<uint8_t> &data = {})
-        : success(ok), message(msg), payload(data)
-    {}
+    Response(bool ok, const std::string& msg, const std::vector<uint8_t>& data = {})
+        : success(ok), message(msg), payload(data) {}
 };
 
 /*
@@ -58,16 +52,16 @@ struct Response
 
   Required Methods (from specification):
     ServiceManager() (default constructor)
-    void RegisterDocumentQueue(DocumentQueue* queue)
-    void RegisterContentModeration(ContentModeration* moderation)
-    void RegisterUpgradeManager(UpgradeManager* upgradeMgr)
+    void RegisterDocumentQueue(rxrevoltchain::core::DocumentQueue* queue)
+    void RegisterContentModeration(rxrevoltchain::pinner::ContentModeration* moderation)
+    void RegisterUpgradeManager(rxrevoltchain::network::UpgradeManager* upgradeMgr)
     Response HandleRequest(const Request &req)
 
   "Fully functional" approach:
    - We store pointers to DocumentQueue, ContentModeration, UpgradeManager.
    - In HandleRequest, we parse req.requestType to decide which subsystem to invoke.
    - We produce a Response containing success/failure, message, and optional payload.
-   - The request payload format (JSON, binary, etc.) is not strictly defined here. 
+   - The request payload format (JSON, binary, etc.) is not strictly defined here.
      We'll do minimal or example-based parsing. For real usage, parse properly (JSON libs, etc.).
 
    Example request types (illustrative):
@@ -77,38 +71,30 @@ struct Response
    - You can expand or modify as needed. Here we show basic dispatch logic.
 
   THREAD-SAFETY:
-   - We use a mutex around global data if needed. If the underlying subsystems 
+   - We use a mutex around global data if needed. If the underlying subsystems
      are also thread-safe, we only need minimal additional locking here.
 */
 
-class ServiceManager
-{
-public:
+class ServiceManager {
+  public:
     // Default constructor
     ServiceManager()
-        : m_documentQueue(nullptr)
-        , m_contentModeration(nullptr)
-        , m_upgradeManager(nullptr)
-    {
-    }
+        : m_documentQueue(nullptr), m_contentModeration(nullptr), m_upgradeManager(nullptr) {}
 
     // Register DocumentQueue pointer
-    void RegisterDocumentQueue(DocumentQueue* queue)
-    {
+    void RegisterDocumentQueue(rxrevoltchain::core::DocumentQueue* queue) {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_documentQueue = queue;
     }
 
     // Register ContentModeration pointer
-    void RegisterContentModeration(ContentModeration* moderation)
-    {
+    void RegisterContentModeration(rxrevoltchain::pinner::ContentModeration* moderation) {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_contentModeration = moderation;
     }
 
     // Register UpgradeManager pointer
-    void RegisterUpgradeManager(UpgradeManager* upgradeMgr)
-    {
+    void RegisterUpgradeManager(rxrevoltchain::network::UpgradeManager* upgradeMgr) {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_upgradeManager = upgradeMgr;
     }
@@ -117,101 +103,79 @@ public:
       HandleRequest:
       - Dispatches to the appropriate subsystem based on req.requestType.
       - Returns a Response indicating success/failure, plus a message/payload if needed.
-      - For demonstration, we do simple if-else handling. Real code might parse request payload more elaborately.
+      - For demonstration, we do simple if-else handling. Real code might parse request payload more
+      elaborately.
     */
-    Response HandleRequest(const Request &req)
-    {
+    Response HandleRequest(const Request& req) {
         std::lock_guard<std::mutex> lock(m_mutex);
 
-        if (req.requestType == "AddDocument")
-        {
+        if (req.requestType == "AddDocument") {
             // Example: interpret req.payload as a transaction. Real code would parse actual data.
-            if (!m_documentQueue)
-            {
+            if (!m_documentQueue) {
                 return Response(false, "DocumentQueue not registered.");
             }
 
             // Fake minimal parse: we assume the entire payload is the "metadata"
-            Transaction tx;
+            rxrevoltchain::core::Transaction tx;
             tx.SetType("document_submission");
             std::string meta((const char*)req.payload.data(), req.payload.size());
             tx.SetMetadata(meta);
 
             // Add to queue
             bool added = m_documentQueue->AddTransaction(tx);
-            if (added)
-            {
+            if (added) {
                 return Response(true, "Document added successfully.");
-            }
-            else
-            {
+            } else {
                 return Response(false, "Failed to add document.");
             }
-        }
-        else if (req.requestType == "RemoveDocument")
-        {
+        } else if (req.requestType == "RemoveDocument") {
             // Similar approach: parse as removal transaction
-            if (!m_documentQueue)
-            {
+            if (!m_documentQueue) {
                 return Response(false, "DocumentQueue not registered.");
             }
 
-            Transaction tx;
+            rxrevoltchain::core::Transaction tx;
             tx.SetType("removal_request");
             std::string meta((const char*)req.payload.data(), req.payload.size());
             tx.SetMetadata(meta);
 
             bool added = m_documentQueue->AddTransaction(tx);
-            if (added)
-            {
+            if (added) {
                 return Response(true, "Removal request queued successfully.");
-            }
-            else
-            {
+            } else {
                 return Response(false, "Failed to queue removal request.");
             }
-        }
-        else if (req.requestType == "ProposeContentRemoval")
-        {
-            if (!m_contentModeration)
-            {
+        } else if (req.requestType == "ProposeContentRemoval") {
+            if (!m_contentModeration) {
                 return Response(false, "ContentModeration not registered.");
             }
 
-            // We might parse the payload to extract cid and reason. 
+            // We might parse the payload to extract cid and reason.
             // For simplicity, let's assume the payload is "cid:reason".
             // Real code should parse properly (JSON, etc.).
             std::string s((const char*)req.payload.data(), req.payload.size());
             auto pos = s.find(':');
-            if (pos == std::string::npos)
-            {
+            if (pos == std::string::npos) {
                 return Response(false, "Invalid format; expected 'cid:reason'");
             }
             std::string cid = s.substr(0, pos);
             std::string reason = s.substr(pos + 1);
 
             bool ok = m_contentModeration->ProposeContentRemoval(cid, reason);
-            if (ok)
-            {
+            if (ok) {
                 return Response(true, "Proposal created/updated for CID: " + cid);
-            }
-            else
-            {
+            } else {
                 return Response(false, "Failed to propose content removal for CID: " + cid);
             }
-        }
-        else if (req.requestType == "VoteOnContentRemoval")
-        {
-            if (!m_contentModeration)
-            {
+        } else if (req.requestType == "VoteOnContentRemoval") {
+            if (!m_contentModeration) {
                 return Response(false, "ContentModeration not registered.");
             }
 
             // Example parse: "cid:approve:voterID"
             std::string s((const char*)req.payload.data(), req.payload.size());
             auto tokens = splitString(s, ':');
-            if (tokens.size() != 3)
-            {
+            if (tokens.size() != 3) {
                 return Response(false, "Invalid format; expected 'cid:approveOrDeny:voterID'");
             }
             std::string cid = tokens[0];
@@ -219,12 +183,10 @@ public:
             std::string voterID = tokens[2];
 
             bool ok = m_contentModeration->VoteOnRemoval(cid, approve, voterID);
-            return ok ? Response(true, "Vote recorded.") : Response(false, "Vote not recorded or proposal not found.");
-        }
-        else if (req.requestType == "IsRemovalApproved")
-        {
-            if (!m_contentModeration)
-            {
+            return ok ? Response(true, "Vote recorded.")
+                      : Response(false, "Vote not recorded or proposal not found.");
+        } else if (req.requestType == "IsRemovalApproved") {
+            if (!m_contentModeration) {
                 return Response(false, "ContentModeration not registered.");
             }
 
@@ -233,19 +195,15 @@ public:
             bool approved = m_contentModeration->IsRemovalApproved(cid);
             return approved ? Response(true, "Removal approved for CID: " + cid)
                             : Response(false, "Removal not approved or proposal not found.");
-        }
-        else if (req.requestType == "ProposeUpgrade")
-        {
-            if (!m_upgradeManager)
-            {
+        } else if (req.requestType == "ProposeUpgrade") {
+            if (!m_upgradeManager) {
                 return Response(false, "UpgradeManager not registered.");
             }
 
             // parse "upgradeID:description"
             std::string s((const char*)req.payload.data(), req.payload.size());
             auto tokens = splitString(s, ':');
-            if (tokens.size() < 2)
-            {
+            if (tokens.size() < 2) {
                 return Response(false, "Invalid format; expected 'upgradeID:description'");
             }
             std::string upgradeID = tokens[0];
@@ -254,20 +212,17 @@ public:
             bool ok = m_upgradeManager->ProposeUpgrade(upgradeID, description);
             return ok ? Response(true, "Upgrade proposed: " + upgradeID)
                       : Response(false, "Failed to propose upgrade or already applied.");
-        }
-        else if (req.requestType == "VoteOnUpgrade")
-        {
-            if (!m_upgradeManager)
-            {
+        } else if (req.requestType == "VoteOnUpgrade") {
+            if (!m_upgradeManager) {
                 return Response(false, "UpgradeManager not registered.");
             }
 
             // parse "upgradeID:approveOrDeny:voterID"
             std::string s((const char*)req.payload.data(), req.payload.size());
             auto tokens = splitString(s, ':');
-            if (tokens.size() != 3)
-            {
-                return Response(false, "Invalid format; expected 'upgradeID:approveOrDeny:voterID'");
+            if (tokens.size() != 3) {
+                return Response(false,
+                                "Invalid format; expected 'upgradeID:approveOrDeny:voterID'");
             }
             std::string upgradeID = tokens[0];
             bool approve = (tokens[1] == "approve");
@@ -276,11 +231,8 @@ public:
             bool ok = m_upgradeManager->VoteOnUpgrade(upgradeID, approve, voterID);
             return ok ? Response(true, "Upgrade vote recorded.")
                       : Response(false, "Vote not recorded. No such upgrade or already applied?");
-        }
-        else if (req.requestType == "IsUpgradeActivated")
-        {
-            if (!m_upgradeManager)
-            {
+        } else if (req.requestType == "IsUpgradeActivated") {
+            if (!m_upgradeManager) {
                 return Response(false, "UpgradeManager not registered.");
             }
 
@@ -288,37 +240,31 @@ public:
             bool activated = m_upgradeManager->IsUpgradeActivated(upgradeID);
             return activated ? Response(true, "Upgrade is activated.")
                              : Response(false, "Upgrade is not activated or doesn't exist.");
-        }
-        else if (req.requestType == "ApplyUpgrade")
-        {
-            if (!m_upgradeManager)
-            {
+        } else if (req.requestType == "ApplyUpgrade") {
+            if (!m_upgradeManager) {
                 return Response(false, "UpgradeManager not registered.");
             }
 
             std::string upgradeID((const char*)req.payload.data(), req.payload.size());
             bool applied = m_upgradeManager->ApplyUpgrade(upgradeID);
-            return applied ? Response(true, "Upgrade applied successfully.")
-                           : Response(false, "Failed to apply upgrade. Not yet activated or doesn't exist.");
-        }
-        else
-        {
+            return applied
+                       ? Response(true, "Upgrade applied successfully.")
+                       : Response(false,
+                                  "Failed to apply upgrade. Not yet activated or doesn't exist.");
+        } else {
             // Unknown request type
             return Response(false, "Unknown request type: " + req.requestType);
         }
     }
 
-private:
+  private:
     // Helper function to split a string on a delimiter
-    std::vector<std::string> splitString(const std::string &input, char delimiter) const
-    {
+    std::vector<std::string> splitString(const std::string& input, char delimiter) const {
         std::vector<std::string> tokens;
         size_t start = 0;
-        while (true)
-        {
+        while (true) {
             size_t pos = input.find(delimiter, start);
-            if (pos == std::string::npos)
-            {
+            if (pos == std::string::npos) {
                 tokens.push_back(input.substr(start));
                 break;
             }
@@ -328,11 +274,11 @@ private:
         return tokens;
     }
 
-private:
+  private:
     mutable std::mutex m_mutex;
-    rxrevoltchain::core::DocumentQueue*        m_documentQueue;
-    rxrevoltchain::pinner::ContentModeration*  m_contentModeration;
-    UpgradeManager*                            m_upgradeManager;
+    rxrevoltchain::core::DocumentQueue* m_documentQueue;
+    rxrevoltchain::pinner::ContentModeration* m_contentModeration;
+    UpgradeManager* m_upgradeManager;
 };
 
 } // namespace network

--- a/src/pinner/pinner_node.hpp
+++ b/src/pinner/pinner_node.hpp
@@ -6,6 +6,9 @@
 #include "document_queue.hpp"
 #include "network/p2p_node.hpp"
 #include "network/protocol_messages.hpp"
+#include "network/service_manager.hpp"
+#include "network/upgrade_manager.hpp"
+#include "pinner/content_moderation.hpp"
 #include "transaction.hpp"
 #include <atomic>
 #include <chrono>
@@ -34,6 +37,11 @@ class PinnerNode {
         // Configure persistent storage for the DocumentQueue
         std::string queueFile = m_config.dataDirectory + "/document_queue.wal";
         m_docQueue.SetStorageFile(queueFile);
+
+        // Register subsystems with the ServiceManager
+        m_serviceManager.RegisterDocumentQueue(&m_docQueue);
+        m_serviceManager.RegisterContentModeration(&m_contentModeration);
+        m_serviceManager.RegisterUpgradeManager(&m_upgradeManager);
 
         m_isNodeRunning = false;
         return true;
@@ -127,6 +135,9 @@ class PinnerNode {
     // Returns a reference to the scheduler for fine-grained control, if needed
     DailyScheduler& GetScheduler() { return m_scheduler; }
 
+    // Access to the ServiceManager for governance RPCs
+    rxrevoltchain::network::ServiceManager& GetServiceManager() { return m_serviceManager; }
+
     // Broadcast a snapshot announcement to peers
     void AnnounceSnapshot(const std::string& cid) {
         rxrevoltchain::network::ProtocolMessage msg;
@@ -181,6 +192,9 @@ class PinnerNode {
     DailyScheduler m_scheduler;
     rxrevoltchain::config::NodeConfig m_config;
     rxrevoltchain::network::P2PNode m_p2pNode;
+    rxrevoltchain::network::ServiceManager m_serviceManager;
+    rxrevoltchain::pinner::ContentModeration m_contentModeration;
+    rxrevoltchain::network::UpgradeManager m_upgradeManager;
 };
 
 } // namespace pinner

--- a/test/test_runner.cpp
+++ b/test/test_runner.cpp
@@ -273,4 +273,41 @@ TEST(PoPConsensusTest, MerkleProofFlow) {
     std::remove(file.c_str());
 }
 
+TEST(ServiceManagerTest, ContentModerationFlow) {
+    rxrevoltchain::network::ServiceManager svc;
+    rxrevoltchain::pinner::ContentModeration mod;
+    svc.RegisterContentModeration(&mod);
+
+    auto toVec = [](const std::string& s) { return std::vector<uint8_t>(s.begin(), s.end()); };
+
+    auto resp = svc.HandleRequest({"ProposeContentRemoval", toVec("cid1:bad")});
+    EXPECT_TRUE(resp.success);
+
+    resp = svc.HandleRequest({"VoteOnContentRemoval", toVec("cid1:approve:node")});
+    EXPECT_TRUE(resp.success);
+
+    resp = svc.HandleRequest({"IsRemovalApproved", toVec("cid1")});
+    EXPECT_TRUE(resp.success);
+}
+
+TEST(ServiceManagerTest, UpgradeActivationFlow) {
+    rxrevoltchain::network::ServiceManager svc;
+    rxrevoltchain::network::UpgradeManager up;
+    svc.RegisterUpgradeManager(&up);
+
+    auto toVec = [](const std::string& s) { return std::vector<uint8_t>(s.begin(), s.end()); };
+
+    auto resp = svc.HandleRequest({"ProposeUpgrade", toVec("u1:desc")});
+    EXPECT_TRUE(resp.success);
+
+    resp = svc.HandleRequest({"VoteOnUpgrade", toVec("u1:approve:node")});
+    EXPECT_TRUE(resp.success);
+
+    resp = svc.HandleRequest({"IsUpgradeActivated", toVec("u1")});
+    EXPECT_TRUE(resp.success);
+
+    resp = svc.HandleRequest({"ApplyUpgrade", toVec("u1")});
+    EXPECT_TRUE(resp.success);
+}
+
 } // anonymous namespace


### PR DESCRIPTION
## Summary
- wire ContentModeration and UpgradeManager into `PinnerNode`
- expose `ServiceManager` accessor
- update ServiceManager to use fully-qualified types
- add unit tests for ServiceManager governance flows
- remove completed TODO item

## Testing
- `test/rxrevoltchain_tests --gtest_filter=ServiceManagerTest.*`