### PR TITLE
Add EHR connector skeleton and update scaling docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core
     ${CMAKE_CURRENT_SOURCE_DIR}/src/network
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/connectors
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ipfs_integration
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pinner
     ${CMAKE_CURRENT_SOURCE_DIR}/src/util

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 #TODO
 
-10. **Scaling and external integrations**
-    - Plan connectors for EHR or insurance systems to auto‑submit data.
-    - Consider partitioning the database when it grows large and manage long‑term maintenance tasks.
-
 11. **Comprehensive test suite**
     - Expand GoogleTest coverage for each module (IPFSPinner, P2P networking, PoP flows, etc.).
     - Provide integration tests that simulate multiple nodes and reward distribution.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -1,4 +1,4 @@
-# RxRevoltChain Whitepaper
+#RxRevoltChain Whitepaper
 
 **Version:** 1.0  
 **Date:** December, 2024
@@ -295,9 +295,15 @@ Healthcare cost transparency is a **global concern**—patients often struggle t
 1. **External API Connectors**
    - Tools or modules to interface with EHR (Electronic Health Record) systems so they can auto-submit cost data,
    - Possibly integrate with insurance providers for direct feed of claims data.
+   - Connectors should speak common standards like FHIR or HL7 and include
+     credential management, batching and retry logic so uploads can happen
+     automatically with minimal user intervention.
 
 2. **Sharding / Partitioning** (If the main DB grows huge)
    - Potentially split the pinned data into multiple region-based or category-based `.sqlite` files, if necessary.
+   - Each partition can be pinned separately to IPFS and referenced from a master
+     index. This keeps individual snapshot sizes manageable while still allowing
+     lookups across partitions when required.
 
 #### 6.2 Maintenance & Upgrades
 
@@ -496,4 +502,4 @@ Launches the pinner node:
 
 1. [IPFS Documentation](https://docs.ipfs.tech/)  
 2. [SQLite Official Documentation](https://www.sqlite.org/docs.html)  
-3. [Filecoin & IPFS Relationship](https://filecoin.io) (for conceptual parallels, though RxRevoltChain differs in approach)  
+3. [Filecoin & IPFS Relationship](https://filecoin.io) (for conceptual parallels, though RxRevoltChain differs in approach)

--- a/src/connectors/ehr_connector.hpp
+++ b/src/connectors/ehr_connector.hpp
@@ -1,0 +1,76 @@
+#ifndef RXREVOLTCHAIN_CONNECTORS_EHR_CONNECTOR_HPP
+#define RXREVOLTCHAIN_CONNECTORS_EHR_CONNECTOR_HPP
+
+#include <curl/curl.h>
+#include <mutex>
+#include <string>
+
+namespace rxrevoltchain {
+namespace connectors {
+
+/**
+ * @brief Simple connector for posting cost data to an external EHR or
+ * insurance system.
+ *
+ * The connector is intentionally lightweight and only supports a basic
+ * POST of JSON payloads. It can be extended with authentication headers,
+ * batching or more advanced error handling as needed.
+ */
+class EHRConnector {
+  public:
+    explicit EHRConnector(const std::string& endpoint) : m_endpoint(endpoint) { initCurl(); }
+
+    /**
+     * @brief Submit a JSON document to the remote endpoint.
+     * @param jsonPayload JSON string representing the cost data.
+     * @return true on success, false otherwise.
+     */
+    bool SubmitCostData(const std::string& jsonPayload) {
+        std::string response;
+        return httpPost(m_endpoint, jsonPayload, response);
+    }
+
+  private:
+    void initCurl() {
+        static std::once_flag flag;
+        std::call_once(flag, []() { curl_global_init(CURL_GLOBAL_DEFAULT); });
+    }
+
+    static size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+        if (!userdata)
+            return 0;
+        std::string* resp = reinterpret_cast<std::string*>(userdata);
+        size_t total = size * nmemb;
+        resp->append(ptr, total);
+        return total;
+    }
+
+    bool httpPost(const std::string& url, const std::string& body, std::string& responseOut) {
+        CURL* curl = curl_easy_init();
+        if (!curl)
+            return false;
+
+        struct curl_slist* headers = nullptr;
+        headers = curl_slist_append(headers, "Content-Type: application/json");
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseOut);
+
+        CURLcode res = curl_easy_perform(curl);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+
+        return res == CURLE_OK;
+    }
+
+    std::string m_endpoint;
+};
+
+} // namespace connectors
+} // namespace rxrevoltchain
+
+#endif // RXREVOLTCHAIN_CONNECTORS_EHR_CONNECTOR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ include_directories(
     ${CMAKE_CURRENT_LIST_DIR}/../src/consensus
     ${CMAKE_CURRENT_LIST_DIR}/../src/core
     ${CMAKE_CURRENT_LIST_DIR}/../src/network
+    ${CMAKE_CURRENT_LIST_DIR}/../src/connectors
     ${CMAKE_CURRENT_LIST_DIR}/../src/ipfs_integration
     ${CMAKE_CURRENT_LIST_DIR}/../src/pinner
     ${CMAKE_CURRENT_LIST_DIR}/../src/util

--- a/test/test_runner.cpp
+++ b/test/test_runner.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv) {
 // Include references to the classes under test.
 // Adjust paths or namespaces as needed if they've changed.
 #include "config/node_config.hpp"
+#include "connectors/ehr_connector.hpp"
 #include "core/daily_snapshot.hpp"
 #include "core/document_queue.hpp"
 #include "core/privacy_manager.hpp"
@@ -343,6 +344,12 @@ TEST(RewardSchedulerTest, StreakPenalty) {
 
     rs.RecordPassingNodes({"node1"});
     EXPECT_EQ(rs.GetNodeStreak("node1"), (uint64_t)1);
+}
+
+TEST(EHRConnectorTest, SubmitFailsWithoutEndpoint) {
+    rxrevoltchain::connectors::EHRConnector conn("http://localhost:9999/api");
+    // Endpoint likely not running; expect failure but function should execute
+    EXPECT_FALSE(conn.SubmitCostData("{}"));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Summary
- add a lightweight `EHRConnector` for posting cost data
- register connector headers in build system and unit tests
- document EHR/insurance integration and DB partitioning
- add unit test exercising the new connector
- remove completed todo item

## Testing
- `scripts/run-tests.sh Release` *(fails: CTest hung while running `rxrevoltchain_tests`)*